### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ $ ``sudo apt install docker-ce``
 $ ``sudo systemctl status docker``  
 
 
-Portainer Command:
-
+# Portainer Install Commands:
 $ ``mkdir docker``  
 $ ``sudo docker volume create portainer_data``  
 $ ``sudo docker run -d -p 8000:8000 -p 9443:9443 --name portainer \

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Portainer Command:
 $ ``mkdir docker``  
 $ ``sudo docker volume create portainer_data``  
 $ ``sudo docker run -d -p 8000:8000 -p 9443:9443 --name portainer \
+    --net=host \
     --restart=always \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v portainer_data:/data \

--- a/README.md
+++ b/README.md
@@ -9,13 +9,12 @@ $ ``sudo apt update``
 $ ``sudo apt install docker-ce``  
 $ ``sudo systemctl status docker``  
 
+## To test Docker you can use this command :
+
+$ ``sudo docker run hello-world ``
+
 
 # Portainer Install Commands:
 $ ``mkdir docker``  
 $ ``sudo docker volume create portainer_data``  
-$ ``sudo docker run -d -p 8000:8000 -p 9443:9443 --name portainer \
-    --net=host \
-    --restart=always \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v portainer_data:/data \
-    portainer/portainer-ce:2.9.3``  
+$ ``sudo docker run -d -p 8000:8000 -p 9443:9443 --name portainer --net=host --restart=always -v /var/run/docker.sock:/var/run/docker.sock -v portainer_data:/data portainer/portainer-ce:2.9.3``  


### PR DESCRIPTION
adding --net=host parameter that allows docker to configure the iptable redirections

Hello,

I had the same issue as you while working with prtainer and docker, Stumbled upon you comment on reddit and followed the link to yout github.
I used the same commands as you but the portainer image started but did not have access to the web interface. After some researches I found out about this command :  --net=host  that I added to the portainer installation command and It perectly worked for me.

Thank you.